### PR TITLE
fix for small bandwidth-downstream

### DIFF
--- a/src/tcpkali_connection.h
+++ b/src/tcpkali_connection.h
@@ -20,6 +20,7 @@
 struct connection {
     tk_io watcher;
     tk_timer timer;
+    double timer_deadline;
     off_t write_offset;
     struct transport_data_spec data;
     non_atomic_traffic_stats traffic_ongoing;  /* Connection-local numbers */


### PR DESCRIPTION
prevent "reading part" of the connecion from reseting timer set by "writing part"

fix for https://github.com/satori-com/tcpkali/issues/44