### PR TITLE
Avoid leaking ssl_fd on every new SSL connection

### DIFF
--- a/src/tcpkali_engine.c
+++ b/src/tcpkali_engine.c
@@ -2854,6 +2854,9 @@ connection_free_internals(struct connection *conn) {
     message_collection_free(&conn->message_collection);
 
 #ifdef HAVE_OPENSSL
+    if(conn->ssl_fd) {
+        SSL_free(conn->ssl_fd);
+    }
     if(conn->ssl_ctx) {
         SSL_CTX_free(conn->ssl_ctx);
     }


### PR DESCRIPTION
I believe this fixes a memory leak when running tcpkali with `--ssl`. The SSL structure created by `SSL_new` in `ssl_setup` were not being freed anywhere, so in a long-running process with a lot of new connections it was possible to leak quite a lot of memory.

We are running tcpkali with `--ssl -c10k` and a multi-day `-T`, and without this patch we see it consuming gigabytes of RAM after a couple of mass reconnections. With this patch its memory usage is steady across reconnections. This graph shows the difference we see:

![Screenshot from 2019-04-08 10-41-57](https://user-images.githubusercontent.com/20528/55832656-e0a03480-5aca-11e9-98e6-8e4547034263.png)