### PR TITLE
Support ipv6 addresses

### DIFF
--- a/src/tcpkali_dns.c
+++ b/src/tcpkali_dns.c
@@ -75,7 +75,7 @@ void
 resolve_address(char *address, struct addrinfo **res) {
     char *hostport = strdup(address);
     char *host = hostport;
-    char *service_string = strchr(hostport, ':');
+    char *service_string = strrchr(hostport, ':');
     if(service_string) {
         *service_string++ = '\0';
     } else {


### PR DESCRIPTION
Semicolons are part of ipv6 notation so we need to look for the last occurrence of ':' using `strrchar` instead of the first one